### PR TITLE
Add a limit to the search results.

### DIFF
--- a/bbid.py
+++ b/bbid.py
@@ -1,34 +1,40 @@
 #!/usr/bin/env python3
-import os, sys, urllib.request, re, threading, posixpath, urllib.parse, argparse, random, socket, time, hashlib, pickle, signal, imghdr
+import os, sys, urllib.request, urllib.error, re, threading, posixpath, urllib.parse, argparse, random, socket, time, hashlib, pickle, signal, imghdr
 
 #config
 output_dir = './bing' #default output dir
 adult_filter = True #Do not disable adult filter by default
 pool_sema = threading.BoundedSemaphore(value = 20) #max number of download threads
 bingcount = 35 #default bing paging
+limit = 10 #default nb results limit
 socket.setdefaulttimeout(2)
 
-in_progress = tried_urls = []
+in_progress = {}
+tried_urls = []
 image_md5s = {}
 urlopenheader={ 'User-Agent' : 'Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0'}
 def download(url,output_dir):
-	if url in tried_urls:
+	search_id = output_dir.split('/')[-1]
+	if search_id not in in_progress:
+		in_progress[search_id] = []
+	if url in tried_urls or len(os.listdir(output_dir)) + len(in_progress[search_id]) > limit:
 		return
-	pool_sema.acquire() 
+	pool_sema.acquire()
 	path = urllib.parse.urlsplit(url).path
 	filename = posixpath.basename(path).split('?')[0] #Strip GET parameters from filename
 	name, ext = os.path.splitext(filename)
 	name = name[:36]
 	filename = name + ext
-
 	i = 0
-	while os.path.exists(os.path.join(output_dir, filename)) or filename in in_progress:
+	while os.path.exists(os.path.join(output_dir, filename)) or filename in in_progress[search_id]:
 		i += 1
 		filename = "%s-%d%s" % (name, i, ext)
-	in_progress.append(filename)
+	in_progress[search_id].append(filename)
+
 	try:
 		request=urllib.request.Request(url,None,urlopenheader)
 		image=urllib.request.urlopen(request).read()
+
 		if not imghdr.what(None, image):
 			print('FAIL: Invalid image, not saving ' + filename)
 			return
@@ -38,32 +44,37 @@ def download(url,output_dir):
 			print('FAIL: Image is a duplicate of ' + image_md5s[md5_key] + ', not saving ' + filename)
 			return
 
-		image_md5s[md5_key] = filename
+		nb_files = len(os.listdir(output_dir))
+		if nb_files >= limit:
+			return
 
+		image_md5s[md5_key] = filename
 		imagefile=open(os.path.join(output_dir, filename),'wb')
 		imagefile.write(image)
 		imagefile.close()
-		print("OK: " + filename)
+		print('OK ("%s" %d/%d): %s' % (search_id, nb_files+1, limit, filename))
 		tried_urls.append(url)
-	except Exception as e:
-		print("FAIL: " + filename)
+	except urllib.error.HTTPError as e:
+		print("FAIL (HTTPError): %s: %s" % (filename, e))
+	except urllib.error.URLError as e:
+		print("FAIL (URLError): %s: %s" % (filename, e))
+	except socket.timeout as e:
+		print("FAIL (timeout): %s: %s" % (filename, e))
+
 	finally:
-		in_progress.remove(filename)
+		in_progress[search_id].remove(filename)
 		pool_sema.release()
 
 def fetch_images_from_keyword(keyword,output_dir):
 	current = 1
-	last = ''
-	while True:
+	links = []
+	while len(links)<=limit*2: # We except at last 50% of valid images.
 		request_url='https://www.bing.com/images/async?q=' + urllib.parse.quote_plus(keyword) + '&async=content&first=' + str(current) + '&adlt=' + adlt
 		request=urllib.request.Request(request_url,None,headers=urlopenheader)
 		response=urllib.request.urlopen(request)
 		html = response.read().decode('utf8')
-		links = re.findall('murl&quot;:&quot;(.*?)&quot;',html)
+		links += re.findall('murl&quot;:&quot;(.*?)&quot;',html)
 		try:
-			if links[-1] == last:
-				return
-			last = links[-1]
 			current += bingcount
 			for link in links:
 				t = threading.Thread(target = download,args = (link,output_dir))
@@ -88,6 +99,7 @@ if __name__ == "__main__":
 	parser.add_argument('-s', '--search-string', help = 'Keyword to search', required = False)
 	parser.add_argument('-f', '--search-file', help = 'Path to a file containing search strings line by line', required = False)
 	parser.add_argument('-o', '--output', help = 'Output directory', required = False)
+	parser.add_argument('-l', '--limit', type = int, help = 'Number of results limit', required = False)
 	parser.add_argument('--filter', help ='Enable adult filter', action = 'store_true', required = False)
 	parser.add_argument('--no-filter', help = 'Disable adult filter', action = 'store_true', required = False)
 	args = parser.parse_args()
@@ -95,6 +107,8 @@ if __name__ == "__main__":
 		parser.error('Provide Either search string or path to file containing search strings')
 	if args.output:
 		output_dir = args.output
+	if args.limit:
+		limit = args.limit
 	if not os.path.exists(output_dir):
 		os.makedirs(output_dir)
 	output_dir_origin = output_dir


### PR DESCRIPTION
The problem: Bing Image website has been updated in order to add an infinite scroll. As a consequence, the image downloader never reach the end of the page, and downloads images without stopping. This is mainly unexpected when the user set the `-f` option, because the script downloads only images about the first line in the search file.

This PR adds a limit to the search results. This parameter can be provided by the user with the `-l`
 or `--limit` cli option (10 by default).

usage:

```
# Download 10 images of "Jon snow":
./bbid.py -s "Jon snow"
# Download 20 images of "Jon snow", 20 of "Arya Stark" and 20 of "Daenerys":
echo "Jon Snow\nArya Stark\nDaenerys" > search
./bbid.py -f ./search -l 20
```

The output has also been updated to display the process and more information about eventual errors:

```
OK ("Jon_Snow" 1/10): jon-snow-1024.jpg
history_dumped
OK ("Jon_Snow" 2/10): jon-snow-holds-pink-letter-game-of-t.jpg
OK ("Jon_Snow" 3/10): jon-snow.jpg
history_dumped
OK ("Jon_Snow" 4/10): jon-snow-resurrected.png
OK ("Ary_Stark" 1/10): Arry.jpg
OK ("Ary_Stark" 2/10): arya-stark.jpg
FAIL (HTTPError): latest: HTTP Error 404: Not Found
OK ("Jon_Snow" 5/10): jon%20snow%20game%20of%20thrones.png
OK ("Ary_Stark" 3/10): 1eb9e9d58be2ec4ee5afed96178d6399.jpg
OK ("Jon_Snow" 6/10): jon%20snow%20season%20six%20game%20o.png
OK ("Jon_Snow" 7/10): Jon-Snow-4.jpg
OK ("Ary_Stark" 4/10): Arya_Stark_4.jpg
```