### PR TITLE
Improve --limit precision and apply minor changes in print messages

### DIFF
--- a/bbid.py
+++ b/bbid.py
@@ -15,6 +15,7 @@ def download(pool_sema: threading.Semaphore, url: str, output_dir: str):
     global in_progress
 
     if url in tried_urls:
+        print('Already checked ' + url + ', skipped')
         return
     pool_sema.acquire()
     in_progress += 1

--- a/bbid.py
+++ b/bbid.py
@@ -75,7 +75,7 @@ def fetch_images_from_keyword(pool_sema: threading.Semaphore, keyword: str, outp
             if links[-1] == last:
                 return
             for index, link in enumerate(links):
-                if limit is not None and current + index >= limit:
+                if limit is not None and current >= limit:
                     return
                 t = threading.Thread(target = download,args = (pool_sema, link, output_dir))
                 t.start()


### PR DESCRIPTION
I find --limit useful, although it is not very precise. Currently the --limit option is exploited at line 78 (`if limit is not None and current + index >= limit:`), however, as far as I understood, `current + index` has the meaning of representing the number of links analyzed (hence an upper bound to the images downloaded). I guess the idea was to have `current` constant w.r.t. each search and use `index` as an offset that increase at every link, but during the enumeration of the links both `current` and `index` are incremented, hence the actual upper bound is `limit/2`. So if you don't like this pull request, I suggest at least to change line 78 to `if limit is not None and current >= limit:`.

The purpose of this pull request is making `limit` indicating exactly the number of images downloaded (provided that there are enough images in the search). To do so, two modifications were required.
- I modified the condition in `if limit is not None and len(tried_urls) >= limit:`, since an url is contained in `tried_urls` iff it reached the end of the try block which happens iff it was downloaded successfully. The result is that links are passed to `download` until the desired number of images is reached.
- I modified `download` to make it check if the number of images already downloaded reached the desired value before downloading a new image (with the same condition mentioned above). Doing so required the addition of a semaphore to avoid problems due to the concurrent reading and writing of `tried_urls`. The smoothest way I found to implement this was to perform the last part of the try block within the semaphore and releasing the semaphore in the finally block. Obviously this implies a general slowdown since only one thread can save an image to disk at the time, however this operation should be very fast if compared to the downloading part, that still happens in parallel, hence I don't think it can be a bottleneck. Since now `download` requires both an additional semaphore and the `limit` value, I had to modify the parameters of `download` and `fetch_images_from_keyword` accordingly.

Note 1. There is a little time interval when many `download` threads started but the limit has already been reached, these threads will still download the images but without saving them to file. The resource waste is small but, eventually, it can be reduced by adding another check before the download.
Note 2. There is no risk of deadlock even if `threads = 1`. To get the `img_sema` a thread must have the `pool_sema`, hence there is no risk that a thread has `pool_sema` without `img_sema` and another one has `img_sema` without `pool_sema`.

Finally, I performed minor modifications to the log messages: now all of them start with a 4 char word representing the type of message (` OK `, `SKIP`, `FAIL`).